### PR TITLE
Some edits on the REKS recipes

### DIFF
--- a/docs/reks/advanced.rst
+++ b/docs/reks/advanced.rst
@@ -1,18 +1,20 @@
+.. _sec-advanced_REKS:
 
-============================================
+*********************
 Advanced calculations
-============================================
+*********************
 
-************************
-Nonadiabatic couplings
-************************
+
+Non-adiabatic couplings
+=======================
 
 [Input: `recipes/reks/nonadiabatic_coupling/`]
 
-The nonadiabatic coupling vectors between the states can be calculated with SSR method.
-By setting ``NonAdiabaticCoupling = Yes`` in ``REKS`` block, the user can easily
-calculate the nonadiabatic coupling vectors. When this option is turned on, SSR shows
-the gradients for all states and possible coupling vectors::
+The non-adiabatic coupling vectors between the states can be calculated with the
+SSR method. By setting ``NonAdiabaticCoupling = Yes`` in ``REKS`` block, the
+user can easily calculate the non-adiabatic coupling vectors. When this option is
+turned on, SSR shows the gradients for all states and possible coupling
+vectors::
 
   --------------------------------------------------
    Gradient Information
@@ -70,30 +72,34 @@ the gradients for all states and possible coupling vectors::
        0.00076359     0.00034700     0.00000000
   --------------------------------------------------
 
-These gradients and coupling vectors are obtained with planar structure of a ethylene molecule.
-The g vector is defined as gradient difference vector, thus it can be calculated from the
-difference of SA-REKS gradients. Similarly to this, G vector is calculated from the difference
-of SSR gradients. The h vector is defined as coupling gradient, so it can be simply calculated
-from the gradient of state-interaction terms. The H vector is defined as derivative coupling
-vectors, thus its norm increases as the energy gap becomes smaller.
+The above gradients and coupling vectors are obtained with the planar structure
+of a ethylene molecule.  The *g* vector is defined as gradient difference
+vector, thus it can be calculated from the difference of SA-REKS
+gradients. Similarly to this, *G* vector is calculated from the difference of
+SSR gradients. The *h* vector is defined as coupling gradient, so it can be
+simply calculated from the gradient of state-interaction terms. The *H* vector
+is defined as the derivative of the coupling vectors, thus its norm increases as
+the energy gap becomes smaller.
 
-The g and h vectors can be regarded as the vectors defined through diabatic states, and G and
-H vectors are defined through the adiabatic (SSR) states. In general, the nonadiabatic coupling
-vectors can be used for Ehrenfest or surface hopping molecular dynamics, while the g and h vectors
-can be used for minimum energy conical intersction (MECI) optimisation.
+The *g* and *h* vectors can be regarded as the vectors defined through diabatic
+states, and the *G* and *H* vectors are defined through the adiabatic (SSR)
+states. In general, the non-adiabatic coupling vectors can be used for surface
+hopping molecular dynamics, while the *g* and *h* vectors can be used for
+minimum energy conical intersection (MECI) optimisation.
 
-************************
 Relaxed Density
-************************
+===============
 
 [Input: `recipes/reks/relaxed_density/`]
 
-The relaxed density is calculated according to ``TargetState`` when the user sets ``RelaxedDensity``
-to ``Yes``. The calculation of relaxed density requires the information about gradient, thus it
-can be calculated when the input includes calculation of gradient. When this option is turned on,
-the relaxed FONs are given in the bottom of standard output and *relaxed_charge.dat* file is
-generated. It includes total charge as well as the mulliken charges of each atom for target state.
-This example shows relaxed charges for ground state::
+The relaxed density is calculated for the ``TargetState`` when the user sets
+``RelaxedDensity`` to ``Yes``. The calculation of a relaxed density requires the
+information about gradient, thus it can be calculated when the input enables
+gradient calculation. When this option is turned on, the relaxed FONs are given
+in the bottom of standard output and the *relaxed_charge.dat* file is
+generated. It includes the total charge as well as the Mulliken charges of each
+atom for target state.  This example shows relaxed charges for the ground
+state::
 
   total charge:     -0.00000000 (e)
 
@@ -106,35 +112,42 @@ This example shows relaxed charges for ground state::
         5       0.09084308
         6       0.09084308
 
-If one want to exploit SSR with QM/MM approach, ``RelaxedDensity`` option should be used to
-obtain the gradient of external point charges. Then, the gradient of external point charges
-for target state are given in *detailed.out* file. Therefore, this option can be used to run
-Ehrenfest or surface hopping dynamics with QM/MM approach.
+If one want to exploit SSR with a QM/MM approach, the ``RelaxedDensity`` option
+should be used to obtain the gradient of external point charges. Then, the
+gradient of external point charges for target state are given in *detailed.out*
+file. Therefore, this option can be used to run surface hopping dynamics with a
+QM/MM approach.
 
-************************
 Spin tuning constants
-************************
+=====================
 
-DFTB/SSR method can well describe equilibrium geometries as well as vertical excitation energies
-compared with SSR/wPBEh result. (See the paper `JCTC, 2019, 15, 3021-3032.
-<https://pubs.acs.org/doi/10.1021/acs.jctc.9b00132>`_) However, the behaviours at MECI points
-does not sometimes match those obtained with SSR/wPBEh. For example, n/:math:`\pi^*` type MECI
-geometry of ethylene or methyliminium molecule cannot be located with DFTB/SSR, and different
-calculation results mainly originate from an incorrect description of the relative stability of
-the PPS and OSS states. Their relative stability depends on the splitting between the open-shell
-singlet microstates and the triplet microstates in the PPS and OSS energies.
+The DFTB/SSR method well describes equilibrium geometries and vertical
+excitation energies as compared with SSR/wPBEh results. (See the paper `JCTC,
+2019, 15, 3021-3032.  <https://pubs.acs.org/doi/10.1021/acs.jctc.9b00132>`_)
+However, the behaviours at MECI points sometimes does not match those obtained
+with SSR/wPBEh. For example, the n/:math:`\pi^*` type MECI geometry of ethylene
+or methyliminium molecule cannot be located with DFTB/SSR, with an incorrect
+description of the relative stability of the PPS and OSS states being mostly
+responsible. Their relative stability depends on the splitting between the
+open-shell singlet microstates and the triplet microstates in the PPS and OSS
+energies.
 
-In principle, DFTB/SSR employs spin-polarized DFTB formalism, in which the spin-polarization
-contribution is obtained from the second-order expansion of the magnetization density with 
-respect to zero magnetization electronic structure. At the n/:math:`\pi^*` type MECI geometries,
-both frontier orbitals are located on the same atom. In such a case, the second-order expansion
-of magnetization may not be suitable for the triplet microstates, as the spin density becomes
-too large. As a simple solution, the stability between the PPS and OSS states can be adjusted
-by scaling the atomic spin constants. For most molecules the FONs for PPS state become :math:`n_a`
-~ 2.0 and :math:`n_b` ~ 0.0, hence the energy of the PPS state is determined by 1st microstate
-alone and it is the energy of the OSS state that depends the atomic spin constants. If the user
-run the test calculation included in $DFTB/test/prog/dftb+/reks/PSB3_2SSR_rangesep_tuning directory,
-then followng results can be given in the standard output::
+In principle, DFTB/SSR employs spin-polarised DFTB formalism, in which the
+spin-polarisation contribution is obtained from the second-order expansion of
+the magnetisation density with respect to zero magnetisation electronic
+structure. At the n/:math:`\pi^*` type MECI geometries, both frontier orbitals
+are located on the same atom. In such a case, the second-order expansion of
+magnetisation may not be suitable for the triplet microstates, as the spin
+density becomes too large. As a simple solution, the stability between the PPS
+and OSS states can be adjusted by scaling the atomic spin constants. For most
+molecules the FONs for the PPS state become :math:`n_a` ~ 2.0 and :math:`n_b` ~
+0.0, hence the energy of the PPS state is determined by the 1\ :sup:`st`
+microstate alone and it is only the energy of the OSS state that depends on the
+atomic spin constants.
+
+If the user runs the test calculation included with the main DFTB+ repository in
+the `test/prog/dftb+/reks/PSB3_2SSR_rangesep_tuning` directory, the following
+results are given in the standard output::
 
   ----------------------------------------------------------------
    SSR: 2SI-2SA-REKS(2,2) states
@@ -159,9 +172,10 @@ then followng results can be given in the standard output::
       0.04971872    -0.03074284     0.01547016
       0.06968625     0.18189801     0.04542884
 
-It shows the energies at MECI point of PSB3 molecule, thus the nonadiabatic coupling vectors show
-large elements near center C=C bond. Similary to this, the atomic spin constants can be modified
-by using ``SpinTuning`` keyword in ``REKS`` block as follows::
+It shows the energies at MECI point of a PSB3 molecule, thus the non-adiabatic
+coupling vectors show large elements near to the centre C=C bond. The atomic
+spin constants can be modified by using ``SpinTuning`` keyword in ``REKS`` block
+as follows::
 
   Reks = SSR22 {
     Energy = {
@@ -184,16 +198,16 @@ by using ``SpinTuning`` keyword in ``REKS`` block as follows::
     VerbosityLevel = 1
   }
 
-************************
 Microstate calculation
-************************
+======================
 
 [Input: `recipes/reks/microstate/`]
 
-Obviously SSR method treats only singlet state such as PPS or OSS state. If one want to compare
-the energy of singlet and triplet states, SSR provides the energy of triplet configuration as
-an alternative which corresponds to 5th or 6th configuration in (2,2) active space. Thus, the user
-can easily compare the energy of singlet states and triplet microstate.::
+Obviously, the SSR method treats only singlet states like PPS or OSS. If one
+want to compare the energy of singlet and triplet states, SSR provides the
+energy of a triplet configuration as an alternative which corresponds to the 5\
+:sup:`th` or 6\ :sup:`th` configuration in the (2,2) active space. Thus, the
+user can easily compare the energy of singlet and triplet microstates.::
 
   --------------------------------------------------
    Final SA-REKS(2,2) energy:      -4.78921495
@@ -204,14 +218,16 @@ can easily compare the energy of singlet states and triplet microstate.::
    Trip   -4.73085776   1.000000  1.000000  1.00
   --------------------------------------------------
 
-In this example showing the resulting energy of distorted structure of ethylene, the energy of
-triplet microstate is almost similar with that of PPS state since the frontier orbitals are the
-localized :math:`\pi` orbitals in this system. If one want to know the gradient of triplet
-microstate as well as relaxed density, then they can be obtained by using ``TargetMicrostate``
-keyword in ``REKS`` block. If the value for this keyword sets to ``5``, then the properties will
-be calculated according to the index of microstate. In (2,2) active space, 5th microstate indicates
-triplet configuration, thus the output shows the quantities for this microstate. The following
-results are obtained from the distorted structure of ethylene molecule::
+In this example, for a distorted structure of ethylene, the energy of triplet
+microstate is close to that of the PPS state, since the frontier orbitals are
+the localised :math:`\pi` orbitals in this system. If one want to know the
+gradient of the triplet microstate as well as its relaxed density, these can be
+obtained by using ``TargetMicrostate`` keyword in ``REKS`` block. If the value
+for this keyword is to ``5``, then the properties will be calculated according
+to the index of the microstate. In a (2,2) active space, the 5\ :sup:`th`
+microstate indicates a triplet configuration, thus the output shows the
+quantities for this microstate. The following results are obtained from the
+distorted structure of ethylene molecule::
 
   --------------------------------------------------
    Gradient Information
@@ -225,13 +241,15 @@ results are obtained from the distorted structure of ethylene molecule::
       -0.00639516    -0.00417743     0.00000000
   --------------------------------------------------
 
-The gradient is now calculated for 5th microstate. In addition, the energy of spin contribution
-in *detailed.out* file is -0.023 Hartree which corresponds to the spin constant :math:`W_{pp}` for
-carbon atom. In this case the frontier orbitals are consisted of only p orbitals of carbon atom,
-thus the energy of spin contribution is mostly consisted of interactions between p orbitals of
-carbon atom. With this option, one can run the molecular dynamics simulation for triplet microstate.
+The gradient is now calculated for the 5\ :sup:`th` microstate. In addition, the
+energy of spin contribution in the *detailed.out* file is -0.023, Hartree which
+corresponds to the spin constant :math:`W_{pp}` for a carbon atom. In this case
+the frontier orbitals consisted of only `p` orbitals of a carbon atom, thus the
+energy of the spin contribution mostly consists of interactions between these
+orbitals. With this option, one can run the molecular dynamics simulation for
+the triplet microstate.
 
-This example shows input file for calculation of triplet microstate::
+This example shows an input file for calculation of a triplet microstate::
 
   Reks = SSR22 {
     Energy = {
@@ -250,6 +268,5 @@ This example shows input file for calculation of triplet microstate::
     VerbosityLevel = 1
   }
 
-Note that ``TargetMicrostate`` keyword can be used with only SA-REKS input settings as above.
-
-
+Note that ``TargetMicrostate`` keyword can be used only with the SA-REKS input
+settings discussed above.

--- a/docs/reks/error-handling.rst
+++ b/docs/reks/error-handling.rst
@@ -1,15 +1,16 @@
+.. _reks_errors:
 
-============================================
+************************
 Error handling with REKS
-============================================
+************************
 
-************************
-Oscillation of energy
-************************
+
+Oscillation of energy during SCC
+================================
 
 [Input: `recipes/reks/oscillation_energy/`]
 
-The oscillation of SA-REKS energy in SCC process may appear as follows::
+The oscillation of SA-REKS energy in the SCC process may appear as follows::
 
     646       -8.9586042135       0.0000229869     0.621642    0.00993712
     647       -8.9586272004      -0.0000229869     0.601626    0.00993712
@@ -21,11 +22,14 @@ The oscillation of SA-REKS energy in SCC process may appear as follows::
     653       -8.9586272004      -0.0000229869     0.601626    0.00993712
     654       -8.9586042135       0.0000229869     0.621642    0.00993712
 
-These oscillations mostly arise from the degeneracy of frontier orbitals. As the difference
-between frontier orbitals gets smaller, it is hard to determine the order of frontier orbitals
-in the SCC process. As a result, oscillating phenomena appear in those cases. To solve this,
-the user can increase the shift value by setting ``Shift`` in ``REKS`` block. Then, it may
-show correct variational SA-REKS energy in the SCC process::
+These oscillations mostly arise from the degeneracy of the frontier orbitals. As
+the difference between frontier orbitals gets smaller, it becomes harder to
+determine the order of the frontier orbitals during the SCC process. As a
+result, oscillating phenomena appear in these cases. To solve this, the user can
+increase the shift value by setting ``Shift`` in ``REKS`` block, which increases
+the separation in energy between the lower and upper orbital, stabilising the
+convergence. Smother variational convergence of the SA-REKS energy can occur in
+the SCC process::
 
     111       -8.9586871392      -0.0000000004     0.610476    0.00000117
     112       -8.9586871395      -0.0000000003     0.610474    0.00000110
@@ -41,10 +45,13 @@ show correct variational SA-REKS energy in the SCC process::
    Trip   -8.97307659   1.000000  1.000000  1.00
   --------------------------------------------------
 
-Thus, one can check the FONs become :math:`n_a` ~1.2 and :math:`n_b` ~0.8 in this example. As the
-orbital energies of frontier orbitals are close each other, the user should increase the shift
-value as well as ``MaxSCCIterations``. The oscillation of SA-REKS energy can also occur with
-following irregular pattern::
+Thus, one can check the FONs for the PPS state become :math:`n_a` ~1.2 and
+:math:`n_b` ~0.8 in this example. As the orbital energies of frontier PPS and
+OSS orbitals are close each other, the user should increase the shift value as
+well as the number of ``MaxSCCIterations``.
+
+Oscillation of SA-REKS energy can also occur with the following irregular
+pattern::
 
      84      -11.5656112187       0.0000347081     0.535896    0.00170908
      85      -11.5616527044       0.0039585143     0.533173    0.01062304
@@ -57,18 +64,20 @@ following irregular pattern::
      89      -11.4916836033       0.0647974162     0.993664    0.50049487
      90      -11.5138647944      -0.0221811911     0.999927    0.21955679
 
-******************************************
-Selection of minimized energy functional
-******************************************
+
+Selection energy functional to be minimised
+===========================================
 
 [Input: `recipes/reks/benzene/`]
 
-A benzene has two degenerate :math:`\pi` orbitals and two degenerate :math:`\pi^*` orbitals. Thus,
-if one want to calculate a benzene molecule, then the active space should include two :math:`\pi`
-and two :math:`\pi^*` orbitals. Hence, (2,2) active space may be insufficient to investigate this
-system, but the ground state can be optimized with DFTB/SSR(2,2). Since there is a ambiguous point
-to decide the active space, the OSS state cannot be correctly generated. Thus, only single-state
-REKS is recommended for a benzene molecule, and the resulting energy of PPS state is given in::
+A benzene molecule has two degenerate :math:`\pi` orbitals and two degenerate
+:math:`\pi^*` orbitals. Thus, if one want to calculate this case, then the
+active space should include two :math:`\pi` and two :math:`\pi^*`
+orbitals. Hence, a (2,2) active space may be insufficient to investigate this
+system, but the ground state can be optimised with DFTB/SSR(2,2). Since there is
+an ambiguity in deciding the active space, the OSS state cannot be correctly
+generated. Thus, only single-state REKS is recommended for C\ :sub:`6`\ H\
+:sub:`6`, and the resulting energy of the PPS state is given as::
 
   --------------------------------------------------
     Final REKS(2,2) energy:     -12.56867223
@@ -77,38 +86,41 @@ REKS is recommended for a benzene molecule, and the resulting energy of PPS stat
     PPS  -12.56867223   2.000000  0.000000  0.00
   --------------------------------------------------
 
-Note that the orbital energy of upper frontier orbital (in this case, 16th orbital) in *band.out* file
-is not correctly provided since there is a ambiguous part in single-state REKS method when the Fock
-matrix is constructed as follows::
+Note that the orbital energy of the upper frontier orbital (in this case, the
+16\ :sup:`th` orbital) in the *band.out* file is not correctly provided since
+there is an ambiguous part in the single-state REKS method when the Fock matrix
+is constructed as follows::
 
     14    -6.700  2.00000
     15    -6.700  2.00000
     16    -7.583  0.00000
     17    -1.399  0.00000
 
-This problem only occurs in single-state REKS, thus the band energies are correctly calculated for
-SA-REKS or SSR method.
+This problem only occurs in single-state REKS, thus the band energies are
+correctly calculated for the SA-REKS or SSR methods.
 
-According to the system, there may exist a system to show unstability for a lowest excited singlet
-state, which corresponds to the OSS state. In this case, including only PPS state to minimized energy
-functional is recommended, then the geometry will be optimized successfully. 
+According to the system, there may exist instability for the lowest excited
+singlet state, which corresponds to the OSS state. In this case, including only
+the PPS state to minimised the energy functional is recommended, then the
+geometry will be optimised successfully.
 
-***************************
-Fail of CP-REKS equations
-***************************
+Failure of CP-REKS equations
+============================
 
 [Input: `recipes/reks/acetylene/`]
 
-In general, preconditioned conjugate-gradient algorithm is used to solve CP-REKS equations in analytic
-gradient. It calculates quickly and accurately for most molecules, but it may fail to calculate a
-preconditioner due to the symmetry. Its stable geometry of an acetylene is planar so it shows a high
-symmetry, thus a singularity appears as follows::
+In general, a preconditioned conjugate-gradient algorithm is used to solve
+CP-REKS equations. It calculates quickly and accurately for most molecules, but
+it may fail to calculate a preconditioner due to the system symmetry. The stable
+geometry of an acetylene is planar and shows a high symmetry, thus a singularity
+appears as in this case as follows::
 
   ERROR!
   -> A singularity exists in preconditioner for PCG, set Preconditioner = No
 
-In this case, conjugate-gradient without preconditioner helps to solve CP-REKS equations. Then, the
-CP-REKS equations are now successfully solved as follows::
+In this case, using conjugate-gradient without a preconditioner helps to solve
+CP-REKS equations. The CP-REKS equations are then successfully solved as
+follows::
 
   ----------------------------------------------------------------------------------
    Solving CP-REKS equation for  1 state vector...
@@ -120,5 +132,3 @@ CP-REKS equations are now successfully solved as follows::
   ----------------------------------------------------------------------------------
 
 Therefore, the user can check the geometry and symmetry when these errors occur.
-
-

--- a/docs/reks/error-handling.rst
+++ b/docs/reks/error-handling.rst
@@ -28,7 +28,7 @@ determine the order of the frontier orbitals during the SCC process. As a
 result, oscillating phenomena appear in these cases. To solve this, the user can
 increase the shift value by setting ``Shift`` in ``REKS`` block, which increases
 the separation in energy between the lower and upper orbital, stabilising the
-convergence. Smother variational convergence of the SA-REKS energy can occur in
+convergence. Smoother variational convergence of the SA-REKS energy can occur in
 the SCC process::
 
     111       -8.9586871392      -0.0000000004     0.610476    0.00000117
@@ -46,7 +46,7 @@ the SCC process::
   --------------------------------------------------
 
 Thus, one can check the FONs for the PPS state become :math:`n_a` ~1.2 and
-:math:`n_b` ~0.8 in this example. As the orbital energies of frontier PPS and
+:math:`n_b` ~0.8 in this example. As the orbital energies of the active PPS and
 OSS orbitals are close each other, the user should increase the shift value as
 well as the number of ``MaxSCCIterations``.
 

--- a/docs/reks/index.rst
+++ b/docs/reks/index.rst
@@ -1,18 +1,25 @@
-###################
+####
 REKS
-###################
+####
 
 This chapter discusses REKS (spin-Restricted Ensemble Kohn-Sham) calculations
-for ground and low-lying excited states. This allows the calculation, for example,
-of the state with multireference character as well as the vertical excitation
-energies between the states. REKS can be classified as single-state REKS, SA-REKS,
-and SI-SA-REKS.
+for ground and low-lying excited states. REKS can treat states with strong
+static correlation (`J. Phys. Chem. A 104, 6628
+<https://dx.doi.org/10.1021/jp0002289>`_) and also produces the correct spin
+symmetry in cases where unrestricted methods suffer from spin contamination.
+REKS also allows the calculation of, for example, states with multi-reference
+character as well as the vertical excitation energies between states. REKS can
+be classified as :ref:`single_state_REKS`, :ref:`SA_REKS` and :ref:`SI_SA_REKS`.
 
-In this chapter we will provide example calculations of basic energy and gradient
-calculations, additional functionality such as level shifting and spin tuning,
-and advanced calculations including nonadiabatic couplings between the states and
-relaxed densities which can be used for QM/MM calculations. Finally, we will provide
-helpful error handling methods when we use REKS calculations.
+In this chapter we will
+
+* provide some example calculations of basic energy and gradient evaluation,
+* discuss additional functionality such as level shifting and spin tuning,
+* demonstrate advanced calculations including non-adiabatic couplings between the
+  states and relaxed densities which can be used for QM/MM calculations.
+
+Finally, we will discuss how to diagnose and handle some the problems which can
+specifically arise in REKS calculations.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/reks/introduction.rst
+++ b/docs/reks/introduction.rst
@@ -1,49 +1,47 @@
 .. _sec-reks:
 
-============================================
+******************************************
 Energy and gradient calculations with REKS
-============================================
+******************************************
 
-*******************
+.. _single_state_REKS:
+
 Single-state REKS
-*******************
+=================
 
 [Input: `recipes/reks/single_state_reks/`]
 
-In single-state REKS, only ground state is calculated and it can treat the
-state with multireference character. For example, a ethylene molecule
-with torsional angle of 90 degrees shows degenerate :math:`{\pi}` and
-:math:`{\pi}^*` orbitals, which are correspond to highest occupied molecular
-orbital (HOMO) and lowest unoccupied molecular orbital (LUMO), respectively.
-In this case the SCC-DFTB calculation shows oscillating phenomena for self-consistent
-charges and it cannot obtain a correct variational energy since it cannot consider
-the static electronic correlations. In addition, REKS can deal with bond-breaking,
-diradicals and magnetic couplings.
+In single-state REKS, the ground state is calculated including multi-reference
+character. For example, a ethylene molecule with a torsional angle of 90 degrees
+has degenerate :math:`{\pi}` and :math:`{\pi}^*` orbitals, corresponding to the
+highest occupied molecular orbital (HOMO) and lowest unoccupied molecular
+orbital (LUMO) respectively.  In this case a standard SCC-DFTB calculation can
+show oscillating phenomena when trying to obtain self-consistent charges and is
+missing the static electronic correlations required for a correct variational
+energy. Similarly, REKS can deal with bond-breaking, di-radicals and magnetic
+couplings which are difficult in standard calculations.
 
-To deal with the static electronic correlation, REKS first determines the size for
-active orbitals, and only two electrons in two frontier orbitals (2,2) is supported
-in current version of `DFTB+ <http://www.dftbplus.org>`_.
+To deal with the static electronic correlation, REKS first determines the size
+of the space of active orbitals. Only two electrons in two frontier orbitals,
+`(2,2)`, is supported in current version of `DFTB+ <http://www.dftbplus.org>`_.
 
-.. note:: From the active space, REKS automatically construct possible electronic
-   configurations, called microstate (See the paper `JCTC, 2019, 15, 3021-3032.
-   <https://pubs.acs.org/doi/10.1021/acs.jctc.9b00132>`_). Total 6 microstates
-   are generated in REKS(2,2) calculations, for example, 5th and 6th microstates
-   express high-spin configurations in (2,2) space. To correctly describe spin
-   configurations except doubly-paired microstates, the ``SpinConstants`` block
-   is necessary in ``Hamiltonian`` block. For example, the number of up-electron
-   in 5th microstate is larger than that of down-electron. Thus, the atomic spin
-   constants are used to describe the spin contributions. Note that the user should
-   not include the ``SpinPolarisation`` block, only ``SpinConstants`` block is
-   needed in ``Hamiltonian`` block.
+.. note:: From the active space, REKS automatically construct possible
+   electronic configurations, called microstate (See the paper `JCTC, 2019, 15,
+   3021-3032.  <https://pubs.acs.org/doi/10.1021/acs.jctc.9b00132>`_). A total
+   of 6 microstates are generated in a REKS(2,2) calculations, for example the
+   5\ :sup:`th` and 6\ :sup:`th` microstates express high-spin configurations in
+   the (2,2) space. To correctly describe the spin polarised configurations in
+   the space the ``SpinConstants`` block is required in the ``Hamiltonian``. For
+   example, there are more up-electrons in the 5\ :sup:`th` microstate than
+   down-electrons, thus atomic spin constants are needed to describe spin
+   contributions. Note that the user should not include the ``SpinPolarisation``
+   block, only the ``SpinConstants`` block is needed.
 
-With this active space, the single-state REKS can be carried out using the
-following input that follows::
+With this active space, single-state REKS can be carried out using the following
+input::
 
   Hamiltonian = DFTB {
     SCC = Yes
-    SCCTolerance = 1e-6
-    MaxSCCIterations = 10000
-    Charge = 0.0
     SpinConstants = {
       ShellResolvedSpin = Yes
       H = { -0.072 }
@@ -61,28 +59,34 @@ following input that follows::
     VerbosityLevel = 1
   }
 
-Note that the ``REKS = SSR22`` block is a separate block like ``ExcitedStates`` block,
-which means it is not included in the ``Hamiltonian`` block. In REKS calculation
-``Hamiltonian`` block only controls a detailed Hamiltonian setting such as range-separated
-hybrid functional or dispersion corrections. The three singlet states can be generated
-from (2,2) active space. These are perfectly spin-paired singlet state (PPS), open-shell
-singlet state (OSS) and doubly excited singlet state (DES). Combining these singlet states,
-we can determine the singlet states to be included in minimized energy functional. In
-single-state REKS case we treats only one singlet state and it becomes PPS state. Thus,
-you can only include the PPS state into ``Functional`` block in ``Energy`` block.
+Note that the ``REKS = SSR22`` block is a separate environment in the
+calculation, so is not included in the ``Hamiltonian`` block. In a REKS
+calculation, the ``Hamiltonian`` only controls detailed Hamiltonian settings
+such as use of a range-separated hybrid functional or dispersion
+corrections. Three singlet states can be generated from a (2,2) active
+space. These are the single particle perfectly spin-paired singlet state (PPS),
+an open-shell singlet state (OSS) and the doubly excited singlet state
+(DES). Combining these singlet states, we can find the many-particle singlet
+state which minimises the energy functional. In the single-state REKS case we
+treat only one singlet state of PPS symmetry, thus this is the only possibility
+that can be selected in the ``Functional`` block of the ``Energy`` in this case.
 
-The energy for PPS state is expressed by
+The energy for the PPS state is expressed as
 
 .. math:: E_{PPS} = \sum_L C_L^{PPS} E_L[\rho_L]
 
-where :math:`C_L^{PPS}` is weighting factors of each microstate for PPS state and :math:`E_L`
-is the energy of each microstate. Here the weighting factors are calculated using the
-fractional occupation numbers (FONs) of frontier orbitals, thus the energy of PPS state is
-minimized with respect to the KS orbitals and FONs in single-state REKS.
+where :math:`C_L^{PPS}` are the weighting factors of each microstate in the
+resulting PPS state and :math:`E_L` are their energies. Here the weighting
+factors are calculated using the fractional occupation numbers (FONs) of
+frontier orbitals, thus the energy of the resulting PPS state is minimised with
+respect to both the Kohn-Sham orbitals and the FONs in single-state REKS.
 
-With this inputs, the standard output shows information about the energy of PPS state and
-the FONs contributing the state. The minimized geometry for ethylene is a planar structure
-and the resulting energy and FONs are given in the standard output::
+[Input: `recipes/reks/single_state_reks/dftb_in.hsd-0deg`]
+
+With this inputs, the standard output shows information about the energy of the
+PPS state and the FONs contributing to it. The minimised geometry for ethylene
+is a planar structure and the resulting energy and FONs are given in the
+standard output::
 
   --------------------------------------------------
     Final REKS(2,2) energy:      -4.89357215
@@ -91,12 +95,18 @@ and the resulting energy and FONs are given in the standard output::
     PPS   -4.89357215   1.999990  0.000010  0.00
   --------------------------------------------------
 
-The energy of PPS state is -4.8936 Hartree and the FONs of frontier orbitals are ~2.0 and ~0.0,
-respectively. The orbital character for HOMO is :math:`\pi` and the character for LUMO is
-:math:`\pi^*`, so the two electrons are occupied in the HOMO. When the =CH2 begins to rotate into
-90 degree, the molecular orbitals change from :math:`\pi`, :math:`\pi^*` orbitals to two localized
-single :math:`\pi` orbitals. This means the frontier orbitals are now almost degenerate, and this
-is well described with REKS(2,2) calculations. The resulting energy and FONs are given in::
+The energy of PPS state is -4.8936 Hartree and the FONs of frontier orbitals are
+~2.0 and ~0.0, respectively. The orbital character for HOMO is :math:`\pi` and
+the character for LUMO is :math:`\pi^*`, so the two electrons are occupied in
+the HOMO.
+
+[Input: `recipes/reks/single_state_reks/dftb_in.hsd-90deg`]
+
+When the torsional angle begins to rotate to 90 degree, the molecular orbitals
+change from :math:`\pi` and :math:`\pi^*` orbitals into two localised single
+:math:`\pi` orbitals. This means the frontier orbitals are now almost
+degenerate, and this is well described with REKS(2,2) calculations. The
+resulting energy and FONs are::
 
   --------------------------------------------------
     Final REKS(2,2) energy:      -4.77774313
@@ -105,30 +115,34 @@ is well described with REKS(2,2) calculations. The resulting energy and FONs are
     PPS   -4.77774313   1.000004  0.999996  0.00
   --------------------------------------------------
 
-Now, the energy of PPS state becomes -4.7777 Hartree and the FONs become ~1.0 and ~1.0,
-respectively. In addition, the user can check the energy contribution for the PPS state from
-*detailed.out* file. The energy for spin contribution is ~0.0 Hartree for planar structure,
-while the energy becomes now -0.0188 Hartree for 90 degree rotated structure. Overall, we can
-conclude that the planar structure is almost consisted of only first microstate, while the
-rotated structure is consisted of several microstates.
+Now, the energy of PPS state becomes -4.7777 Hartree and the FONs become ~1.0
+and ~1.0, respectively. In addition, the user can check the energy contributions
+to the PPS state from *detailed.out* file. The energy from the spin contribution
+is ~0.0 Hartree for the planar structure, while the energy becomes -0.0188
+Hartree for the 90 degree rotated structure. Overall, we can conclude that the
+planar structure almost consists of only the first microstate, while the rotated
+structure consists of several microstates.
 
-*******************
+.. _sa_reks:
+
 SA-REKS
-*******************
+=======
 
 [Input: `recipes/reks/sa_reks/`]
 
-Single-state REKS can treat only ground state, thus the vertical excitation energy cannot be
-calculated with this method. From the restricted open-shell Kohn-Sham scheme, we can construct
-the OSS state which is expressed by
+Single-state REKS can treat only the ground state, thus the vertical excitation
+energy cannot be calculated with this method. From the restricted open-shell
+Kohn-Sham scheme, we can construct the OSS state, which is expressed as
 
 .. math:: E_{OSS} = \sum_L C_L^{OSS} E_L[\rho_L]
 
-where :math:`C_L^{OSS}` is weighting factors of each microstate for OSS state. By minimizing
-the energy for the ensemble of PPS and OSS states, we can calculate the vertical excitation
-energy between them with state-average REKS (SA-REKS). Again we can calculate the energy of
-PPS and OSS states of a ethylene molecule with SA-REKS. The ``REKS`` block has now an additional
-``Gradient`` block to calculate the gradient for target state::
+where :math:`C_L^{OSS}` is weighting factors of each microstate making up the
+OSS state. By minimising the energy for the ensemble of PPS and OSS states, we
+can calculate the vertical excitation energy between them with state-average
+REKS (SA-REKS). Again we calculate the energy of the PPS and OSS states of the
+two geometries of an ethylene molecule with SA-REKS. The ``REKS`` block has now
+an additional ``Gradient`` block to calculate the gradient and optimise for the
+target state::
 
   REKS = SSR22 {
     Energy = {
@@ -146,8 +160,9 @@ PPS and OSS states of a ethylene molecule with SA-REKS. The ``REKS`` block has n
     VerbosityLevel = 1
   }
 
-At first the user now have to include the OSS state in ``Functional`` block so that the energy
-of OSS state is calculated. The resulting energy and additional information is given by::
+The user also now has to include the OSS state in addition to the PPS in the
+``Functional`` block so that the energy of both are now calculated. The
+resulting energy and additional information is given by::
 
   --------------------------------------------------
    Final SA-REKS(2,2) energy:      -4.78921495
@@ -169,24 +184,28 @@ of OSS state is calculated. The resulting energy and additional information is g
 
    unrelaxed SA-REKS FONs for S0:  1.999990  0.000010
 
-Here, Final SA-REKS(2,2) energy is the energy of ensemble of PPS and OSS states, which is the quantity
-to be minimized in SA-REKS formalism. For the planar structure of a ethylene molecule, the energies of
-two states are -4.8936 and -4.6849 Hartree, respectively. The FONs for PPS state are ~2.0 and ~0.0, while
-those for OSS state are ~1.0 and ~1.0. In addition, the energy of triplet configuration which corresponds
-to 5th or 6th microstate is now given in the standard output. Note that this energy is not the energy
-of the triplet state. The user can check the successful convergence by comparing two Lagrangian Wab values.
-The two Lagrangian values will become almost same if the energy is converged enough. With the energies and
-coupling terms between them, we can construct the 2 :math:`\times` 2 Hamiltonian matrix in the state basis.
+The final SA-REKS(2,2) energy is from the ensemble of the PPS and OSS states,
+the energy of which is being minimised. For the planar structure of an ethylene
+molecule, the energies of two states are -4.8936 and -4.6849 Hartree,
+respectively. The FONs for the PPS state are ~2.0 and ~0.0, while those for OSS
+state are ~1.0 and ~1.0. In addition, the energy of the triplet configuration
+which corresponds to contributions from the 5\ :sup:`th` and 6\ :sup:`th`
+microstates is now given in the standard output. Note that this energy is *not*
+the energy of the triplet state. The user can check for successful convergence
+by comparing the two Lagrangian *Wab* values, these will become almost the same
+if the energy is well converged.
 
-After the energy calculation is finished, the gradient for target state, which is PPS state in this example,
-is calculated and the final gradient appears at the bottom of the standard output. The keywords in the
-``Gradient`` block affect coupled-perturbed REKS (CP-REKS) equations which are used to calculate the gradient
-of target state. Here we choose conjugate gradient solver and the keywords ``Preconditioner`` and ``SaveMemory``
-are used to accelerate the computational speed of CP-REKS. These two keywords will be switched off depending on
-users system.
+After the energy calculation is finished, the gradient for the target state
+(TargetState = 1, which is the PPS state in this example) is calculated and the
+final gradient appears at the bottom of the standard output. The keywords in the
+``Gradient`` block affect coupled-perturbed REKS (CP-REKS) equations which are
+used to calculate the gradient of target state. Here we choose a conjugate
+gradient solver and the keywords ``Preconditioner`` and ``SaveMemory`` are used
+to accelerate the computational speed of CP-REKS. These two keywords may be
+switched off depending on the user's system.
 
-Similar to the one above, the distorted structure can be calculated using SA-REKS and the results are given
-in the following::
+Similar to the case above, the distorted structure can be calculated using
+SA-REKS and the results are given in the following::
 
   --------------------------------------------------
    Final SA-REKS(2,2) energy:      -4.75910919
@@ -208,29 +227,34 @@ in the following::
 
    unrelaxed SSR FONs for S0:  1.000000  1.000000
 
-Now the energy of OSS state is -4.7407 Hartree and the coupling between PPS and OSS states becomes non-zero value.
-The energy of triplet configuration is similar with the energy of PPS state. Since REKS can consider the static
-electronic correlations, it can show a correct shape for the potential energy curve with respect to the torsional
-angle of C=C bond. If you want to calculate the energy of DES state, then ``IncludeAllStates = Yes`` keyword in
-the ``Energy`` block will show the energy of DES state as well as the FONs.
+Now the energy of OSS state is -4.7407 Hartree. The energy of the triplet
+configuration is similar to the energy of PPS state. Since REKS can consider the
+static electronic correlations, it can produce the correct shape for the
+potential energy curve with respect to the torsional angle of C=C bond. If you
+want to calculate the energy of the DES state, then ``IncludeAllStates = Yes``
+keyword in the ``Energy`` block will produce the energy of DES state as well as
+its FONs.
 
-*******************
+.. _si_sa_reks:
+
 SI-SA-REKS
-*******************
+==========
 
 [Input: `recipes/reks/si_sa_reks/`]
 
-State-interaction SA-REKS (SI-SA-REKS, briefly SSR) energies are obtained by solveing 2 :math:`\times` 2 secular
-equation with the possible couplings between the electronic states.
+State-interaction SA-REKS (SI-SA-REKS, briefly `SSR`) energies are obtained by
+solving a 2 :math:`\times` 2 secular equation with the possible couplings
+between the electronic states.
 
 .. math:: \left(\begin{array}{cc} E^{PPS} & \Delta^{SA} \\ \Delta^{SA} & E^{OSS} \end{array}\right)
           \left(\begin{array}{cc} a_{00} & a_{01} \\ a_{10} & a_{11} \end{array}\right) =
           \left(\begin{array}{cc} E^{SSR}_0 & 0 \\ 0 & E^{SSR}_1 \end{array}\right)
           \left(\begin{array}{cc} a_{00} & a_{01} \\ a_{10} & a_{11} \end{array}\right)
 
-By considering the state-interaction terms, SSR states become more reliable states when the excited states are
-included. SSR states can be calculated with the ``StateInteractions = Yes`` in ``Energy`` block. For the
-planar structure, the resulting energies are given by::
+By considering the state-interaction terms, the SSR states become more reliable
+when the excited states are included. The SSR states can be calculated with the
+``StateInteractions = Yes`` in ``Energy`` block. For the planar structure, the
+resulting energies are given by::
 
   ----------------------------------------------------------------
    SSR: 2SI-2SA-REKS(2,2) states
@@ -239,7 +263,6 @@ planar structure, the resulting energies are given by::
    SSR state  2   -4.68485776  -0.000000  -1.000000
   ----------------------------------------------------------------
 
-In this case the ground state is consisted of PPS state, while the lowest excited state is consisted of
-OSS state. As the coupling term increases, the difference between SA-REKS and SSR energies becomes larger.
-
-
+In this case, the ground state consists of the PPS state, while the lowest
+excited state is of OSS type. As the coupling term increases, the difference
+between the SA-REKS and SSR energies becomes larger.

--- a/docs/reks/introduction.rst
+++ b/docs/reks/introduction.rst
@@ -64,12 +64,12 @@ calculation, so is not included in the ``Hamiltonian`` block. In a REKS
 calculation, the ``Hamiltonian`` only controls detailed Hamiltonian settings
 such as use of a range-separated hybrid functional or dispersion
 corrections. Three singlet states can be generated from a (2,2) active
-space. These are the single particle perfectly spin-paired singlet state (PPS),
-an open-shell singlet state (OSS) and the doubly excited singlet state
-(DES). Combining these singlet states, we can find the many-particle singlet
-state which minimises the energy functional. In the single-state REKS case we
-treat only one singlet state of PPS symmetry, thus this is the only possibility
-that can be selected in the ``Functional`` block of the ``Energy`` in this case.
+space. These are the perfectly spin-paired singlet state (PPS), an open-shell
+singlet state (OSS) and the doubly excited singlet state (DES). Combining these
+singlet states, we can find the many-particle singlet state which minimises the
+energy functional. In the single-state REKS case we treat only one singlet state
+of PPS symmetry, thus this is the only possibility that can be selected in the
+``Functional`` block of the ``Energy`` in this case.
 
 The energy for the PPS state is expressed as
 


### PR DESCRIPTION
Some suggested changes and hyperlink adjustments:

* Spell checking and grammar changes
* Possible further explanation of some concepts (please check these are correct)
* Removal of comments about Ehrenfest in REKS section, as electron dynamics and Ehrenfest are mean-field approximations to dynamics, but REKS would provide actual level dynamics (if implemented). I agree with the level hopping parts of the comments.

Please check that I have not changed the sense of the descriptions.

Also, are all of the supplied dftb_in example files used? It looks like most of them are relevant, but not directly referenced in the text.